### PR TITLE
Add jsmin

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "devDependencies": {
     "bower": "^1.8.0",
+    "jsmin": "^1.0.1",
     "pulp": "^10.0.0",
     "purescript": "^0.10.5",
     "rollup": "^0.41.1",
@@ -21,8 +22,12 @@
     "build:psc-bundle": "pulp build --main Main --optimise --to dist/js/psc-bundle.js && yarn run uglify:psc-bundle",
     "build:pulp-browserify": "pulp browserify --main Main --optimise --to dist/js/pulp-browserify.js && yarn run uglify:pulp-browserify",
     "uglify:rollup": "uglifyjs dist/js/rollup.js --output dist/js/rollup.min.js --screw-ie8 --mangle --compress",
+    "jsmin:rollup": "jsmin dist/js/rollup.js > dist/js/rollup.jsmin.js",
     "uglify:webpack": "uglifyjs dist/js/webpack.js --output dist/js/webpack.min.js --screw-ie8 --mangle --compress",
+    "jsmin:webpack": "jsmin dist/js/webpack.js > dist/js/webpack.jsmin.js",
     "uglify:psc-bundle": "uglifyjs dist/js/psc-bundle.js --output dist/js/psc-bundle.min.js --screw-ie8 --mangle --compress",
-    "uglify:pulp-browserify": "uglifyjs dist/js/pulp-browserify.js --output dist/js/pulp-browserify.min.js --screw-ie8 --mangle --compress"
+    "jsmin:psc-bundle": "jsmin dist/js/psc-bundle.js > dist/js/psc-bundle.jsmin.js",
+    "uglify:pulp-browserify": "uglifyjs dist/js/pulp-browserify.js --output dist/js/pulp-browserify.min.js --screw-ie8 --mangle --compress",
+    "jsmin:pulp-browserify": "jsmin dist/js/pulp-browserify.js > dist/js/pulp-browserify.jsmin.js"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1681,6 +1681,10 @@ jsbn@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.0.tgz#650987da0dd74f4ebf5a11377a2aa2d273e97dfd"
 
+jsmin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jsmin/-/jsmin-1.0.1.tgz#e7bd0dcd6496c3bf4863235bf461a3d98aa3b98c"
+
 json-loader@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.4.tgz#8baa1365a632f58a3c46d20175fc6002c96e37de"
@@ -2613,13 +2617,13 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.6, rimraf@~2.5.1, rimraf@~2.5.4:
+rimraf@2, rimraf@~2.5.1, rimraf@~2.5.4:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:
     glob "^7.0.5"
 
-rimraf@~2.2.6:
+rimraf@^2.2.6, rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 


### PR DESCRIPTION
Looks like rollup beats psc-bundle with jsmin, too: 110k for psc-bundle
vs 95k for rollup.